### PR TITLE
Use UTC timestamp for training entries

### DIFF
--- a/OnePushup/Services/TrainingService.cs
+++ b/OnePushup/Services/TrainingService.cs
@@ -17,9 +17,7 @@ public class TrainingService
     {
         var entry = new TrainingEntry
         {
-            DateTime = DateTime.Now.Kind == DateTimeKind.Local ? 
-                DateTime.Now.ToUniversalTime() : 
-                DateTime.UtcNow,
+            DateTime = DateTime.UtcNow,
             NumberOfRepetitions = repetitions,
             UserId = userId
         };


### PR DESCRIPTION
## Summary
- Simplify CreateEntryAsync in `TrainingService` to use `DateTime.UtcNow` directly when storing training entries

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae061eeee4832ea12d7216c96ed985