### PR TITLE
Refactor notification setting methods to use shared updater

### DIFF
--- a/OnePushup/Services/NotificationService.cs
+++ b/OnePushup/Services/NotificationService.cs
@@ -87,18 +87,14 @@ public class NotificationService
     {
         try
         {
-            Preferences.Default.Set(EnabledKey, enabled);
-            
-            // Schedule or cancel notifications based on the new setting
-            var settings = await GetNotificationSettingsAsync();
-            if (enabled && settings.Time.HasValue)
+            var current = await GetNotificationSettingsAsync();
+            var updated = new NotificationSettings
             {
-                await ScheduleNotificationAsync(settings.Time.Value);
-            }
-            else
-            {
-                await CancelNotificationsAsync();
-            }
+                Enabled = enabled,
+                Time = current.Time
+            };
+
+            await UpdateNotificationSettingsAsync(updated);
         }
         catch (Exception ex)
         {
@@ -111,14 +107,14 @@ public class NotificationService
     {
         try
         {
-            Preferences.Default.Set(TimeKey, time.Ticks);
-            
-            // If notifications are enabled, reschedule with the new time
-            var settings = await GetNotificationSettingsAsync();
-            if (settings.Enabled)
+            var current = await GetNotificationSettingsAsync();
+            var updated = new NotificationSettings
             {
-                await ScheduleNotificationAsync(time);
-            }
+                Enabled = current.Enabled,
+                Time = time
+            };
+
+            await UpdateNotificationSettingsAsync(updated);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Simplify notification enable/time setters by delegating to `UpdateNotificationSettingsAsync`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0906528c832e9f08ef111d2950f7