### PR TITLE
Refactor GetCurrentUserAsync to expression-bodied method

### DIFF
--- a/OnePushup/Services/UserService.cs
+++ b/OnePushup/Services/UserService.cs
@@ -13,10 +13,7 @@ public class UserService
         _usersRepository = usersRepository;
     }
 
-    public async Task<User?> GetCurrentUserAsync()
-    {
-        return await _usersRepository.GetAsync();
-    }
+    public Task<User?> GetCurrentUserAsync() => _usersRepository.GetAsync();
 
     public async Task<UserDto?> GetCurrentUserDtoAsync()
     {


### PR DESCRIPTION
## Summary
- simplify GetCurrentUserAsync by using expression-bodied syntax and removing unnecessary async/await

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08fac458832e9f97d687d098cd2d