### PR TITLE
Optimize streak data retrieval by parallelizing repository calls

### DIFF
--- a/OnePushup/Services/TrainingService.cs
+++ b/OnePushup/Services/TrainingService.cs
@@ -65,15 +65,17 @@ public class TrainingService
 
     public async Task<StreakDataDto> GetStreakDataAsync(Guid userId)
     {
-        var currentStreak = await _trainingEntryRepository.GetCurrentStreakAsync(userId);
-        var streakTotal = await _trainingEntryRepository.GetTotalPushupsInCurrentStreakAsync(userId);
-        var totalPushups = await _trainingEntryRepository.GetTotalPushupsAsync(userId);
+        var currentStreakTask = _trainingEntryRepository.GetCurrentStreakAsync(userId);
+        var streakTotalTask = _trainingEntryRepository.GetTotalPushupsInCurrentStreakAsync(userId);
+        var totalPushupsTask = _trainingEntryRepository.GetTotalPushupsAsync(userId);
+
+        await Task.WhenAll(currentStreakTask, streakTotalTask, totalPushupsTask);
 
         return new StreakDataDto
         {
-            CurrentStreak = currentStreak,
-            PushupsInCurrentStreak = streakTotal,
-            TotalPushups = totalPushups
+            CurrentStreak = await currentStreakTask,
+            PushupsInCurrentStreak = await streakTotalTask,
+            TotalPushups = await totalPushupsTask
         };
     }
 


### PR DESCRIPTION
## Summary
- Parallelize streak data retrieval by launching repository calls concurrently
- Await all tasks and populate the DTO from task results

## Testing
- ⚠️ `dotnet test` *(dotnet CLI missing and installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae162c7b28832e8f14e8e22608e968