### PR TITLE
Use AsNoTracking for read queries

### DIFF
--- a/OnePushup/Repositories/TrainingEntryRepository.cs
+++ b/OnePushup/Repositories/TrainingEntryRepository.cs
@@ -56,14 +56,16 @@ public class TrainingEntryRepository : ITrainingEntryRepository
         var todayEndUtc = userLocalToday.end.ToUniversalTime();
         
         return await _db.TrainingEntries
-            .FirstOrDefaultAsync(e => e.UserId == userId && 
-                                    e.DateTime >= todayStartUtc && 
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.UserId == userId &&
+                                    e.DateTime >= todayStartUtc &&
                                     e.DateTime < todayEndUtc);
     }
     
     public async Task<List<TrainingEntry>> GetEntriesForUserAsync(Guid userId)
     {
         return await _db.TrainingEntries
+            .AsNoTracking()
             .Where(e => e.UserId == userId)
             .OrderByDescending(e => e.DateTime)
             .ToListAsync();
@@ -72,6 +74,7 @@ public class TrainingEntryRepository : ITrainingEntryRepository
     private async Task<Dictionary<DateTime, int>> GetEntriesByLocalDateAsync(Guid userId)
     {
         var entries = await _db.TrainingEntries
+            .AsNoTracking()
             .Where(e => e.UserId == userId && e.NumberOfRepetitions > 0)
             .OrderByDescending(e => e.DateTime)
             .ToListAsync();
@@ -89,6 +92,7 @@ public class TrainingEntryRepository : ITrainingEntryRepository
         var todayEndUtc = dateRange.end.ToUniversalTime();
 
         var todayEntry = await _db.TrainingEntries
+            .AsNoTracking()
             .FirstOrDefaultAsync(e => e.UserId == userId &&
                                     e.DateTime >= todayStartUtc &&
                                     e.DateTime < todayEndUtc);
@@ -156,6 +160,7 @@ public class TrainingEntryRepository : ITrainingEntryRepository
     public async Task<int> GetTotalPushupsAsync(Guid userId)
     {
         return await _db.TrainingEntries
+            .AsNoTracking()
             .Where(e => e.UserId == userId)
             .SumAsync(e => e.NumberOfRepetitions);
     }

--- a/OnePushup/Repositories/UsersRepository.cs
+++ b/OnePushup/Repositories/UsersRepository.cs
@@ -19,7 +19,9 @@ public class UsersRepository : IUsersRepository
     
     public async Task<User?> GetAsync()
     {
-        return await _db.Users.FirstOrDefaultAsync();
+        return await _db.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync();
     }
 
     public async Task UpdateAsync(User user)


### PR DESCRIPTION
## Summary
- Avoid EF Core tracking for read operations in TrainingEntryRepository
- Query UsersRepository without tracking

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae18af924c832ea9c8f52b5ab8b9c2