### PR TITLE
Handle Android back button with soft exit

### DIFF
--- a/OnePushup/Platforms/Android/MainActivity.cs
+++ b/OnePushup/Platforms/Android/MainActivity.cs
@@ -9,4 +9,8 @@ namespace OnePushUp;
                            ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    public override void OnBackPressed()
+    {
+        MoveTaskToBack(true);
+    }
 }


### PR DESCRIPTION
## Summary
- Override Android `OnBackPressed` to move the task to the background for a soft exit.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19f5c6c4832ebd9aacfee9bd3c93