### PR TITLE
Use constant for default notification time

### DIFF
--- a/OnePushup/Platforms/Android/NotificationReceiver.cs
+++ b/OnePushup/Platforms/Android/NotificationReceiver.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using OnePushUp.Services;
 using System;
 
 namespace OnePushUp.Platforms.Android;
@@ -303,7 +304,7 @@ public class NotificationReceiver : BroadcastReceiver
             if (timeTicks == 0)
             {
                 Logger.LogInformation("NotificationReceiver: No notification time stored, using default");
-                timeTicks = new TimeSpan(8, 0, 0).Ticks; // Default to 8:00 AM
+                timeTicks = NotificationService.DefaultNotificationTime.Ticks; // Default to 8:00 AM
             }
 
             var time = TimeSpan.FromTicks(timeTicks);
@@ -489,7 +490,7 @@ public class NotificationReceiver : BroadcastReceiver
             if (timeTicks == 0)
             {
                 Logger.LogInformation("NotificationReceiver: No notification time stored, using default");
-                timeTicks = new TimeSpan(8, 0, 0).Ticks; // Default to 8:00 AM
+                timeTicks = NotificationService.DefaultNotificationTime.Ticks; // Default to 8:00 AM
             }
 
             TimeSpan scheduledTime = TimeSpan.FromTicks(timeTicks);

--- a/OnePushup/Services/NotificationService.cs
+++ b/OnePushup/Services/NotificationService.cs
@@ -19,36 +19,37 @@ public class NotificationService
     private const string EnabledKey = "notifications_enabled";
     private const string TimeKey = "notification_time";
     private const string LastScheduledKey = "last_notification_scheduled";
+    public static readonly TimeSpan DefaultNotificationTime = TimeSpan.FromHours(8);
 
     public NotificationService(ILogger<NotificationService> logger)
     {
         _logger = logger;
     }
 
-    public Task<NotificationSettings> GetNotificationSettingsAsync()
+    public async Task<NotificationSettings> GetNotificationSettingsAsync()
     {
         try
         {
             var enabled = Preferences.Default.Get(EnabledKey, false);
-            
+
             // Time is stored as ticks
             var timeTicks = Preferences.Default.Get(TimeKey, 0L);
-            TimeSpan? time = timeTicks > 0 ? TimeSpan.FromTicks(timeTicks) : new TimeSpan(8, 0, 0);
-            
-            return Task.FromResult(new NotificationSettings
+            TimeSpan? time = timeTicks > 0 ? TimeSpan.FromTicks(timeTicks) : DefaultNotificationTime;
+
+            return new NotificationSettings
             {
                 Enabled = enabled,
                 Time = time
-            });
+            };
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving notification settings");
-            return Task.FromResult(new NotificationSettings
+            return new NotificationSettings
             {
                 Enabled = false,
-                Time = new TimeSpan(8, 0, 0) // Default to 8:00 AM
-            });
+                Time = DefaultNotificationTime // Default to 8:00 AM
+            };
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize default notification time in `NotificationService`
- reuse constant across Android receiver
- streamline retrieval of notification settings

## Testing
- ⚠️ `dotnet build` *(command not found)*
- ⚠️ `apt-get update` *(403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aea6b87298832e96db0b90e5d5c023