### PR TITLE
Refactor Android notification handling into services

### DIFF
--- a/OnePushup/MauiProgram.cs
+++ b/OnePushup/MauiProgram.cs
@@ -30,6 +30,8 @@ public static class MauiProgram
         builder.Services.AddTransient<UserService>();
 #if ANDROID
         builder.Services.AddSingleton<INotificationScheduler, AndroidNotificationScheduler>();
+        builder.Services.AddSingleton<IAlarmScheduler, AlarmScheduler>();
+        builder.Services.AddSingleton<INotificationDisplayer, NotificationDisplayer>();
 #else
         builder.Services.AddSingleton<INotificationScheduler, DefaultNotificationScheduler>();
 #endif

--- a/OnePushup/Platforms/Android/AlarmScheduler.cs
+++ b/OnePushup/Platforms/Android/AlarmScheduler.cs
@@ -1,0 +1,384 @@
+using Android.App;
+using Android.Content;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Storage;
+using OnePushUp.Services;
+
+namespace OnePushUp.Platforms.Android;
+
+public interface IAlarmScheduler
+{
+    void RestoreNotificationsAfterReboot(Context context);
+    void RescheduleForTomorrow(Context context);
+}
+
+public class AlarmScheduler : IAlarmScheduler
+{
+    private readonly ILogger<AlarmScheduler> _logger;
+    private const string EnabledKey = "notifications_enabled";
+    private const string TimeKey = "notification_time";
+
+    public AlarmScheduler(ILogger<AlarmScheduler> logger)
+    {
+        _logger = logger;
+    }
+
+    public void RestoreNotificationsAfterReboot(Context context)
+    {
+        try
+        {
+            bool enabled = Preferences.Default.Get(EnabledKey, false);
+            if (!enabled)
+            {
+                _logger.LogInformation("Notifications were disabled, not restoring");
+                return;
+            }
+
+            long timeTicks = Preferences.Default.Get(TimeKey, 0L);
+            if (timeTicks == 0)
+            {
+                _logger.LogInformation("No notification time stored, using default");
+                timeTicks = NotificationService.DefaultNotificationTime.Ticks;
+            }
+
+            var time = TimeSpan.FromTicks(timeTicks);
+            _logger.LogInformation("Restoring notification for {Time}", time.ToString("hh\\:mm"));
+
+            var now = DateTime.Now;
+            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
+            calendar.Set(Java.Util.CalendarField.HourOfDay, time.Hours);
+            calendar.Set(Java.Util.CalendarField.Minute, time.Minutes);
+            calendar.Set(Java.Util.CalendarField.Second, 0);
+            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
+
+            var nowMillis = Java.Lang.JavaSystem.CurrentTimeMillis();
+            if (calendar.TimeInMillis <= nowMillis)
+            {
+                calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
+            }
+
+            var triggerAtMillis = calendar.TimeInMillis;
+            _logger.LogInformation("Will trigger at {CalendarTime}", calendar.Time);
+
+            var alarmManager = context.GetSystemService(Context.AlarmService) as AlarmManager;
+            if (alarmManager == null)
+            {
+                _logger.LogError("Failed to get AlarmManager service");
+                return;
+            }
+
+            var exactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            exactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 1);
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "exact");
+
+            var exactPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                1,
+                exactIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            var inexactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            inexactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 2);
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "inexact");
+
+            var inexactPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                2,
+                inexactIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            var repeatingIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            repeatingIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 3);
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "repeating");
+
+            var repeatingPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                3,
+                repeatingIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
+            {
+                try
+                {
+                    alarmManager.SetExactAndAllowWhileIdle(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        exactPendingIntent);
+                    _logger.LogInformation("Exact alarm set after boot");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting exact alarm");
+                }
+
+                try
+                {
+                    alarmManager.Set(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        inexactPendingIntent);
+                    _logger.LogInformation("Inexact alarm set after boot");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting inexact alarm");
+                }
+            }
+            else
+            {
+                try
+                {
+                    alarmManager.SetExact(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        exactPendingIntent);
+                    _logger.LogInformation("Exact alarm set for older Android");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting exact alarm on older Android");
+                }
+            }
+
+            try
+            {
+                alarmManager.SetRepeating(
+                    AlarmType.RtcWakeup,
+                    triggerAtMillis,
+                    AlarmManager.IntervalDay,
+                    repeatingPendingIntent);
+                _logger.LogInformation("Repeating alarm set as backup");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error setting repeating alarm");
+            }
+
+            SetWindowAlarm(context, alarmManager, time, -2, 101);
+            SetWindowAlarm(context, alarmManager, time, -1, 102);
+            SetWindowAlarm(context, alarmManager, time, 1, 103);
+            SetWindowAlarm(context, alarmManager, time, 2, 104);
+
+            _logger.LogInformation("Multiple alarms scheduled after boot/restore");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error restoring notifications");
+        }
+    }
+
+    public void RescheduleForTomorrow(Context context)
+    {
+        try
+        {
+            bool enabled = Preferences.Default.Get(EnabledKey, false);
+            if (!enabled)
+            {
+                _logger.LogInformation("Notifications are disabled, not rescheduling");
+                return;
+            }
+
+            long timeTicks = Preferences.Default.Get(TimeKey, 0L);
+            if (timeTicks == 0)
+            {
+                _logger.LogInformation("No notification time stored, using default");
+                timeTicks = NotificationService.DefaultNotificationTime.Ticks;
+            }
+
+            TimeSpan scheduledTime = TimeSpan.FromTicks(timeTicks);
+            _logger.LogInformation("Rescheduling for tomorrow at {Time}", scheduledTime.ToString("hh\\:mm"));
+
+            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
+            calendar.Set(Java.Util.CalendarField.HourOfDay, scheduledTime.Hours);
+            calendar.Set(Java.Util.CalendarField.Minute, scheduledTime.Minutes);
+            calendar.Set(Java.Util.CalendarField.Second, 0);
+            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
+            calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
+
+            var triggerAtMillis = calendar.TimeInMillis;
+            var alarmManager = context.GetSystemService(Context.AlarmService) as AlarmManager;
+            if (alarmManager == null)
+            {
+                _logger.LogError("Failed to get AlarmManager service for rescheduling");
+                return;
+            }
+
+            var exactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            exactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 1);
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            exactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "exact");
+
+            var exactPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                1,
+                exactIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            var inexactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            inexactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 2);
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            inexactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "inexact");
+
+            var inexactPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                2,
+                inexactIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            var repeatingIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            repeatingIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 3);
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+            repeatingIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "repeating");
+
+            var repeatingPendingIntent = PendingIntent.GetBroadcast(
+                context,
+                3,
+                repeatingIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
+            {
+                try
+                {
+                    alarmManager.SetExactAndAllowWhileIdle(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        exactPendingIntent);
+                    _logger.LogInformation("Alarm rescheduled for tomorrow at {CalendarTime}", calendar.Time);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting exact alarm for tomorrow");
+                }
+
+                try
+                {
+                    alarmManager.Set(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        inexactPendingIntent);
+                    _logger.LogInformation("Inexact alarm rescheduled for tomorrow");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting inexact alarm for tomorrow");
+                }
+            }
+            else
+            {
+                try
+                {
+                    alarmManager.SetExact(
+                        AlarmType.RtcWakeup,
+                        triggerAtMillis,
+                        exactPendingIntent);
+                    _logger.LogInformation("Alarm rescheduled for tomorrow at {CalendarTime}", calendar.Time);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting exact alarm for older Android");
+                }
+            }
+
+            try
+            {
+                alarmManager.SetRepeating(
+                    AlarmType.RtcWakeup,
+                    triggerAtMillis,
+                    AlarmManager.IntervalDay,
+                    repeatingPendingIntent);
+                _logger.LogInformation("Repeating alarm set for tomorrow at {CalendarTime}", calendar.Time);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error setting repeating alarm");
+            }
+
+            SetWindowAlarm(context, alarmManager, scheduledTime, -2, 101);
+            SetWindowAlarm(context, alarmManager, scheduledTime, -1, 102);
+            SetWindowAlarm(context, alarmManager, scheduledTime, 1, 103);
+            SetWindowAlarm(context, alarmManager, scheduledTime, 2, 104);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error rescheduling for tomorrow");
+        }
+    }
+
+    private void SetWindowAlarm(Context context, AlarmManager alarmManager, TimeSpan targetTime, int minuteOffset, int requestCode)
+    {
+        try
+        {
+            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
+            calendar.Set(Java.Util.CalendarField.HourOfDay, targetTime.Hours);
+            calendar.Set(Java.Util.CalendarField.Minute, targetTime.Minutes + minuteOffset);
+            calendar.Set(Java.Util.CalendarField.Second, 0);
+            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
+
+            if (calendar.TimeInMillis <= Java.Lang.JavaSystem.CurrentTimeMillis())
+            {
+                calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
+            }
+
+            var windowTriggerAtMillis = calendar.TimeInMillis;
+
+            var intent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
+            intent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            intent.PutExtra(NotificationIntentConstants.ExtraNotificationId, requestCode);
+            intent.PutExtra(NotificationIntentConstants.ExtraWindowAlarm, true);
+            intent.PutExtra(NotificationIntentConstants.ExtraMinuteOffset, minuteOffset);
+            intent.PutExtra(NotificationIntentConstants.ExtraApproach, $"window_{minuteOffset}");
+
+            var pendingIntent = PendingIntent.GetBroadcast(
+                context,
+                requestCode,
+                intent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
+            {
+                try
+                {
+                    alarmManager.SetExactAndAllowWhileIdle(
+                        AlarmType.RtcWakeup,
+                        windowTriggerAtMillis,
+                        pendingIntent);
+                    _logger.LogInformation("Window alarm set for {Offset} minute(s) offset", (minuteOffset > 0 ? "+" : "") + minuteOffset);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting window alarm");
+                }
+            }
+            else
+            {
+                try
+                {
+                    alarmManager.SetExact(
+                        AlarmType.RtcWakeup,
+                        windowTriggerAtMillis,
+                        pendingIntent);
+                    _logger.LogInformation("Window alarm set for {Offset} minute(s) offset", (minuteOffset > 0 ? "+" : "") + minuteOffset);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error setting window alarm for older Android");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error setting window alarm with offset {Offset}", minuteOffset);
+        }
+    }
+}

--- a/OnePushup/Platforms/Android/AndroidNotificationScheduler.cs
+++ b/OnePushup/Platforms/Android/AndroidNotificationScheduler.cs
@@ -165,10 +165,10 @@ public class AndroidNotificationScheduler : INotificationScheduler
         _logger.LogInformation($"Delay in ms: {delayMs}");
 
         var exactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-        exactIntent.SetAction("com.onepushup.DAILY_NOTIFICATION");
-        exactIntent.PutExtra("notification_id", 1);
-        exactIntent.PutExtra("notification_time", $"{calendar.Time}");
-        exactIntent.PutExtra("approach", "exact");
+        exactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+        exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 1);
+        exactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+        exactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "exact");
 
         var exactPendingIntent = PendingIntent.GetBroadcast(
             context,
@@ -177,10 +177,10 @@ public class AndroidNotificationScheduler : INotificationScheduler
             PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
         var inexactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-        inexactIntent.SetAction("com.onepushup.DAILY_NOTIFICATION");
-        inexactIntent.PutExtra("notification_id", 2);
-        inexactIntent.PutExtra("notification_time", $"{calendar.Time}");
-        inexactIntent.PutExtra("approach", "inexact");
+        inexactIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+        inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 2);
+        inexactIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+        inexactIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "inexact");
 
         var inexactPendingIntent = PendingIntent.GetBroadcast(
             context,
@@ -189,10 +189,10 @@ public class AndroidNotificationScheduler : INotificationScheduler
             PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
         var repeatingIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-        repeatingIntent.SetAction("com.onepushup.DAILY_NOTIFICATION");
-        repeatingIntent.PutExtra("notification_id", 3);
-        repeatingIntent.PutExtra("notification_time", $"{calendar.Time}");
-        repeatingIntent.PutExtra("approach", "repeating");
+        repeatingIntent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+        repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 3);
+        repeatingIntent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{calendar.Time}");
+        repeatingIntent.PutExtra(NotificationIntentConstants.ExtraApproach, "repeating");
 
         var repeatingPendingIntent = PendingIntent.GetBroadcast(
             context,
@@ -403,11 +403,11 @@ public class AndroidNotificationScheduler : INotificationScheduler
             var windowTriggerAtMillis = calendar.TimeInMillis;
 
             var intent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            intent.SetAction("com.onepushup.DAILY_NOTIFICATION");
-            intent.PutExtra("notification_id", requestCode);
-            intent.PutExtra("window_alarm", true);
-            intent.PutExtra("minute_offset", minuteOffset);
-            intent.PutExtra("approach", $"window_{minuteOffset}");
+            intent.SetAction(NotificationIntentConstants.ActionDailyNotification);
+            intent.PutExtra(NotificationIntentConstants.ExtraNotificationId, requestCode);
+            intent.PutExtra(NotificationIntentConstants.ExtraWindowAlarm, true);
+            intent.PutExtra(NotificationIntentConstants.ExtraMinuteOffset, minuteOffset);
+            intent.PutExtra(NotificationIntentConstants.ExtraApproach, $"window_{minuteOffset}");
 
             var pendingIntent = PendingIntent.GetBroadcast(
                 context,
@@ -475,10 +475,10 @@ public class AndroidNotificationScheduler : INotificationScheduler
         try
         {
             var intent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            intent.SetAction("TEST_NOTIFICATION_ALARM");
-            intent.PutExtra("notification_id", 999);
-            intent.PutExtra("test_notification", true);
-            intent.PutExtra("notification_time", $"{DateTime.Now.AddMilliseconds(delayMs):yyyy-MM-dd HH:mm:ss}");
+            intent.SetAction(NotificationIntentConstants.ActionTestNotificationAlarm);
+            intent.PutExtra(NotificationIntentConstants.ExtraNotificationId, 999);
+            intent.PutExtra(NotificationIntentConstants.ExtraTestNotification, true);
+            intent.PutExtra(NotificationIntentConstants.ExtraNotificationTime, $"{DateTime.Now.AddMilliseconds(delayMs):yyyy-MM-dd HH:mm:ss}");
 
             var pendingIntent = PendingIntent.GetBroadcast(
                 context,

--- a/OnePushup/Platforms/Android/MainApplication.cs
+++ b/OnePushup/Platforms/Android/MainApplication.cs
@@ -58,7 +58,7 @@ public class MainApplication : MauiApplication
                         
                         // Send a broadcast to restore notifications
                         Intent restoreIntent = new Intent(this, Java.Lang.Class.FromType(typeof(Platforms.Android.NotificationReceiver)));
-                        restoreIntent.SetAction("RESTORE_NOTIFICATIONS");
+                        restoreIntent.SetAction(Platforms.Android.NotificationIntentConstants.ActionRestoreNotifications);
                         SendBroadcast(restoreIntent);
                         
                         // Also try to schedule directly through the service for redundancy
@@ -102,7 +102,7 @@ public class MainApplication : MauiApplication
         try
         {
             Intent intent = new Intent(ApplicationContext, Java.Lang.Class.FromType(typeof(Platforms.Android.NotificationReceiver)));
-            intent.SetAction("RESTORE_NOTIFICATIONS");
+            intent.SetAction(Platforms.Android.NotificationIntentConstants.ActionRestoreNotifications);
             intent.PutExtra("source", "application_startup");
             SendBroadcast(intent);
             Logger.LogInformation("Sent restore notifications intent to receiver");
@@ -130,8 +130,8 @@ public class PackageReplacedReceiver : BroadcastReceiver
             Logger.LogInformation("App was updated, restoring notifications");
             
             // Send broadcast to our notification receiver
-            Intent notificationIntent = new Intent(context, Java.Lang.Class.FromType(typeof(Platforms.Android.NotificationReceiver)));
-            notificationIntent.SetAction("RESTORE_NOTIFICATIONS");
+                        Intent notificationIntent = new Intent(context, Java.Lang.Class.FromType(typeof(Platforms.Android.NotificationReceiver)));
+                        notificationIntent.SetAction(Platforms.Android.NotificationIntentConstants.ActionRestoreNotifications);
             notificationIntent.PutExtra("source", "package_replaced");
             context.SendBroadcast(notificationIntent);
         }

--- a/OnePushup/Platforms/Android/NotificationDisplayer.cs
+++ b/OnePushup/Platforms/Android/NotificationDisplayer.cs
@@ -1,0 +1,183 @@
+using Android.App;
+using Android.Content;
+using Android.OS;
+using AndroidX.Core.App;
+using Microsoft.Extensions.Logging;
+
+namespace OnePushUp.Platforms.Android;
+
+public interface INotificationDisplayer
+{
+    void ShowPushupNotification(Context context, Intent intent);
+    void ShowTestNotification(Context context, Intent intent);
+}
+
+public class NotificationDisplayer : INotificationDisplayer
+{
+    private readonly ILogger<NotificationDisplayer> _logger;
+
+    public NotificationDisplayer(ILogger<NotificationDisplayer> logger)
+    {
+        _logger = logger;
+    }
+
+    public void ShowPushupNotification(Context context, Intent intent)
+    {
+        try
+        {
+            var notificationManager = NotificationManager.FromContext(context);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.O)
+            {
+                var channel = new NotificationChannel(
+                    "pushup_reminders",
+                    "Pushup Reminders",
+                    NotificationImportance.High)
+                {
+                    Description = "Daily reminders to do your pushups",
+                    LockscreenVisibility = NotificationVisibility.Public
+                };
+
+                channel.EnableVibration(true);
+
+                notificationManager.CreateNotificationChannel(channel);
+                _logger.LogInformation("Notification channel created");
+            }
+
+            var notificationIntent = new Intent(context, Java.Lang.Class.ForName("onepushup.MainActivity"));
+            notificationIntent.SetFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop | ActivityFlags.NewTask);
+            notificationIntent.SetAction(Intent.ActionMain);
+            notificationIntent.AddCategory(Intent.CategoryLauncher);
+
+            var pendingIntent = PendingIntent.GetActivity(
+                context,
+                0,
+                notificationIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            string timeString = intent.GetStringExtra(NotificationIntentConstants.ExtraNotificationTime) ?? DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+            _logger.LogInformation("Notification time from intent: {Time}", timeString);
+
+            int iconId;
+            try
+            {
+                iconId = context.Resources.GetIdentifier("notification_icon", "drawable", context.PackageName);
+                if (iconId == 0)
+                {
+                    iconId = context.Resources.GetIdentifier("ic_notification", "drawable", context.PackageName);
+                }
+
+                if (iconId == 0)
+                {
+                    iconId = global::Android.Resource.Drawable.IcDialogInfo;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error finding custom icon");
+                iconId = global::Android.Resource.Drawable.IcDialogInfo;
+            }
+
+            string approach = intent.GetStringExtra(NotificationIntentConstants.ExtraApproach) ?? "default";
+
+            var builder = new NotificationCompat.Builder(context, "pushup_reminders")
+                .SetContentTitle("OnePushUp Reminder")
+                .SetContentText($"Time to do your daily pushup! ({approach})")
+                .SetSmallIcon(iconId)
+                .SetContentIntent(pendingIntent)
+                .SetAutoCancel(true)
+                .SetPriority(NotificationCompat.PriorityHigh)
+                .SetVisibility(NotificationCompat.VisibilityPublic)
+                .SetCategory(NotificationCompat.CategoryAlarm)
+                .SetDefaults(NotificationCompat.DefaultAll);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.Q)
+            {
+                builder.SetFullScreenIntent(pendingIntent, true);
+            }
+
+            int notificationId = intent.GetIntExtra(NotificationIntentConstants.ExtraNotificationId, 1);
+            notificationManager.Notify(notificationId, builder.Build());
+
+            _logger.LogInformation("Pushup notification displayed with ID {NotificationId} at {Time}", notificationId, DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+
+            WakeDeviceScreen(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error showing notification");
+        }
+    }
+
+    public void ShowTestNotification(Context context, Intent intent)
+    {
+        try
+        {
+            var notificationManager = NotificationManager.FromContext(context);
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.O)
+            {
+                var channel = new NotificationChannel(
+                    "pushup_reminders",
+                    "Pushup Reminders",
+                    NotificationImportance.High)
+                {
+                    Description = "Daily reminders to do your pushups",
+                    LockscreenVisibility = NotificationVisibility.Public
+                };
+
+                channel.EnableVibration(true);
+                notificationManager.CreateNotificationChannel(channel);
+            }
+
+            var notificationIntent = new Intent(context, Java.Lang.Class.ForName("onepushup.MainActivity"));
+            notificationIntent.SetFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop | ActivityFlags.NewTask);
+            notificationIntent.SetAction(Intent.ActionMain);
+            notificationIntent.AddCategory(Intent.CategoryLauncher);
+
+            var pendingIntent = PendingIntent.GetActivity(
+                context,
+                0,
+                notificationIntent,
+                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
+
+            int iconId = global::Android.Resource.Drawable.IcDialogInfo;
+
+            var builder = new NotificationCompat.Builder(context, "pushup_reminders")
+                .SetContentTitle("OnePushUp Test")
+                .SetContentText($"Notification system is working! Current time: {DateTime.Now:HH:mm:ss}")
+                .SetSmallIcon(iconId)
+                .SetContentIntent(pendingIntent)
+                .SetAutoCancel(true)
+                .SetPriority(NotificationCompat.PriorityHigh)
+                .SetVisibility(NotificationCompat.VisibilityPublic);
+
+            int notificationId = intent.GetIntExtra(NotificationIntentConstants.ExtraNotificationId, 999);
+            notificationManager.Notify(notificationId, builder.Build());
+
+            _logger.LogInformation("Test notification displayed at {Time}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error showing test notification");
+        }
+    }
+
+    private void WakeDeviceScreen(Context context)
+    {
+        try
+        {
+            var powerManager = context.GetSystemService(Context.PowerService) as PowerManager;
+            if (powerManager == null) return;
+
+            var wakeLock = powerManager.NewWakeLock(WakeLockFlags.ScreenBright | WakeLockFlags.AcquireCausesWakeup, "OnePushUp::NotificationWakeLock");
+            wakeLock.Acquire(5000);
+
+            _logger.LogInformation("Acquired wake lock to ensure notification visibility");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error waking device screen");
+        }
+    }
+}

--- a/OnePushup/Platforms/Android/NotificationIntentConstants.cs
+++ b/OnePushup/Platforms/Android/NotificationIntentConstants.cs
@@ -1,0 +1,17 @@
+namespace OnePushUp.Platforms.Android;
+
+public static class NotificationIntentConstants
+{
+    // Intent actions
+    public const string ActionDailyNotification = "com.onepushup.DAILY_NOTIFICATION";
+    public const string ActionRestoreNotifications = "RESTORE_NOTIFICATIONS";
+    public const string ActionTestNotificationAlarm = "TEST_NOTIFICATION_ALARM";
+
+    // Intent extras
+    public const string ExtraNotificationId = "notification_id";
+    public const string ExtraNotificationTime = "notification_time";
+    public const string ExtraApproach = "approach";
+    public const string ExtraTestNotification = "test_notification";
+    public const string ExtraWindowAlarm = "window_alarm";
+    public const string ExtraMinuteOffset = "minute_offset";
+}

--- a/OnePushup/Platforms/Android/NotificationReceiver.cs
+++ b/OnePushup/Platforms/Android/NotificationReceiver.cs
@@ -1,708 +1,81 @@
 using Android.App;
 using Android.Content;
-using Android.OS;
-using AndroidX.Core.App;
-using Microsoft.Maui.Storage;
 using Microsoft.Maui;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using OnePushUp.Services;
-using System;
 
 namespace OnePushUp.Platforms.Android;
 
 [BroadcastReceiver(Enabled = true, Exported = true)]
-[IntentFilter(new[] { 
-    Intent.ActionBootCompleted, 
+[IntentFilter(new[] {
+    Intent.ActionBootCompleted,
     Intent.ActionLockedBootCompleted,
     "android.intent.action.QUICKBOOT_POWERON",
     "android.intent.action.MY_PACKAGE_REPLACED"
 })]
 public class NotificationReceiver : BroadcastReceiver
 {
-    private const string EnabledKey = "notifications_enabled";
-    private const string TimeKey = "notification_time";
-    
-    // System alarm actions
-    private const string ACTION_DAILY_NOTIFICATION = "com.onepushup.DAILY_NOTIFICATION";
-    private const string ACTION_RESTORE_NOTIFICATIONS = "RESTORE_NOTIFICATIONS";
-
     private ILogger<NotificationReceiver> Logger => _logger ??=
         MauiApplication.Current?.Services?.GetService<ILogger<NotificationReceiver>>()
         ?? NullLogger<NotificationReceiver>.Instance;
     private ILogger<NotificationReceiver>? _logger;
 
+    private IAlarmScheduler? AlarmScheduler => _alarmScheduler ??=
+        MauiApplication.Current?.Services?.GetService<IAlarmScheduler>();
+    private IAlarmScheduler? _alarmScheduler;
+
+    private INotificationDisplayer? NotificationDisplayer => _displayer ??=
+        MauiApplication.Current?.Services?.GetService<INotificationDisplayer>();
+    private INotificationDisplayer? _displayer;
+
     public override void OnReceive(Context context, Intent intent)
     {
         try
         {
-            // Get the action from the intent
             var action = intent.Action;
-            
             Logger.LogInformation("NotificationReceiver: Received intent with action: {Action}", action ?? "null");
-            
-            // Handle system boot or package replaced
-            if (action == Intent.ActionBootCompleted || 
-                action == Intent.ActionLockedBootCompleted || 
-                action == "android.intent.action.QUICKBOOT_POWERON" || 
+
+            if (action == Intent.ActionBootCompleted ||
+                action == Intent.ActionLockedBootCompleted ||
+                action == "android.intent.action.QUICKBOOT_POWERON" ||
                 action == "android.intent.action.MY_PACKAGE_REPLACED" ||
-                action == ACTION_RESTORE_NOTIFICATIONS)
+                action == NotificationIntentConstants.ActionRestoreNotifications)
             {
                 Logger.LogInformation("NotificationReceiver: System boot or app updated, restoring notifications");
-                RestoreNotificationsAfterReboot(context);
+                AlarmScheduler?.RestoreNotificationsAfterReboot(context);
                 return;
             }
-            
-            // Handle test notification
-            bool isTestNotification = intent.GetBooleanExtra("test_notification", false);
+
+            bool isTestNotification = intent.GetBooleanExtra(NotificationIntentConstants.ExtraTestNotification, false);
             if (isTestNotification)
             {
                 Logger.LogInformation("NotificationReceiver: Handling test notification");
-                ShowTestNotification(context, intent);
+                NotificationDisplayer?.ShowTestNotification(context, intent);
                 return;
             }
-            
-            // For all other notifications, show the regular notification
-            if (action == ACTION_DAILY_NOTIFICATION || 
-                action == "DAILY_NOTIFICATION_EXACT" || 
-                action == "DAILY_NOTIFICATION_INEXACT" || 
+
+            if (action == NotificationIntentConstants.ActionDailyNotification ||
+                action == "DAILY_NOTIFICATION_EXACT" ||
+                action == "DAILY_NOTIFICATION_INEXACT" ||
                 action == "DAILY_NOTIFICATION_REPEAT" ||
                 action == "WINDOW_NOTIFICATION_ALARM" ||
-                action == "TEST_NOTIFICATION_ALARM")
+                action == NotificationIntentConstants.ActionTestNotificationAlarm)
             {
-                ShowPushupNotification(context, intent);
-                
-                // Reschedule for tomorrow regardless of which type of notification triggered
-                RescheduleForTomorrow(context);
+                NotificationDisplayer?.ShowPushupNotification(context, intent);
+                AlarmScheduler?.RescheduleForTomorrow(context);
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "NotificationReceiver: Error in OnReceive");
-            
-            // Try to reschedule anyway if there was an error
             try
             {
-                RescheduleForTomorrow(context);
+                AlarmScheduler?.RescheduleForTomorrow(context);
             }
             catch
             {
-                // Ignore errors in the rescue attempt
             }
-        }
-    }
-    
-    private void ShowPushupNotification(Context context, Intent intent)
-    {
-        try
-        {
-            var notificationManager = NotificationManager.FromContext(context);
-            
-            // Create the notification channel (required for API 26+)
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.O)
-            {
-                var channel = new NotificationChannel(
-                    "pushup_reminders",
-                    "Pushup Reminders",
-                    NotificationImportance.High)
-                {
-                    Description = "Daily reminders to do your pushups",
-                    LockscreenVisibility = NotificationVisibility.Public
-                };
-                
-                // Enable vibration separately
-                channel.EnableVibration(true);
-                
-                notificationManager.CreateNotificationChannel(channel);
-                Logger.LogInformation("NotificationReceiver: Notification channel created");
-            }
-            
-            // Create the notification with an intent that opens the app
-            var notificationIntent = new Intent(context, Java.Lang.Class.ForName("onepushup.MainActivity"));
-            notificationIntent.SetFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop | ActivityFlags.NewTask);
-            notificationIntent.SetAction(Intent.ActionMain);
-            notificationIntent.AddCategory(Intent.CategoryLauncher);
-            
-            var pendingIntent = PendingIntent.GetActivity(
-                context, 
-                0, 
-                notificationIntent, 
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // Get the notification time from intent extras (if available)
-            string timeString = intent.GetStringExtra("notification_time") ?? DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-            Logger.LogInformation("NotificationReceiver: Notification time from intent: {Time}", timeString);
-            
-            // Try to find notification icon by resource ID
-            int iconId;
-            try {
-                // Try multiple ways to get the icon
-                iconId = context.Resources.GetIdentifier("notification_icon", "drawable", context.PackageName);
-                if (iconId == 0)
-                {
-                    // Try the original icon name
-                    iconId = context.Resources.GetIdentifier("ic_notification", "drawable", context.PackageName);
-                }
-                
-                if (iconId == 0)
-                {
-                    // If still not found, try a direct reference
-                    try {
-                        // Remove the direct reference to Resource.Drawable.notification_icon since it doesn't exist
-                        // Use system icon as fallback
-                        iconId = global::Android.Resource.Drawable.IcDialogInfo;
-                    }
-                    catch {
-                        // Ignore if this fails
-                    }
-                }
-                
-                if (iconId == 0)
-                {
-                    Logger.LogWarning("NotificationReceiver: Custom icon not found by any method");
-                    iconId = global::Android.Resource.Drawable.IcDialogInfo; // Fallback to system icon
-                }
-                else
-                {
-                    Logger.LogInformation("NotificationReceiver: Using custom notification icon with id: {IconId}", iconId);
-                }
-            }
-            catch (Exception ex) {
-                Logger.LogError(ex, "NotificationReceiver: Error finding custom icon");
-                iconId = global::Android.Resource.Drawable.IcDialogInfo; // Fallback to system icon
-            }
-            
-            // Get the approach type (for debugging)
-            string approach = intent.GetStringExtra("approach") ?? "default";
-            
-            // Build the main notification
-            var builder = new NotificationCompat.Builder(context, "pushup_reminders")
-                .SetContentTitle("OnePushUp Reminder")
-                .SetContentText($"Time to do your daily pushup! ({approach})")
-                .SetSmallIcon(iconId)
-                .SetContentIntent(pendingIntent)
-                .SetAutoCancel(true)
-                .SetPriority(NotificationCompat.PriorityHigh)
-                .SetVisibility(NotificationCompat.VisibilityPublic)
-                .SetCategory(NotificationCompat.CategoryAlarm)
-                .SetDefaults(NotificationCompat.DefaultAll); // Enable sound, vibration and lights
-            
-            // Add a full screen intent to increase visibility on lock screen
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.Q)
-            {
-                builder.SetFullScreenIntent(pendingIntent, true);
-            }
-            
-            // Show the notification
-            int notificationId = intent.GetIntExtra("notification_id", 1);
-            notificationManager.Notify(notificationId, builder.Build());
-            
-            Logger.LogInformation("NotificationReceiver: Pushup notification displayed with ID {NotificationId} at {Time}", notificationId, DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-            
-            // Wake up the device if screen is off
-            WakeDeviceScreen(context);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error showing notification");
-        }
-    }
-    
-    private void ShowTestNotification(Context context, Intent intent)
-    {
-        try
-        {
-            var notificationManager = NotificationManager.FromContext(context);
-            
-            // Create the notification channel if needed
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.O)
-            {
-                var channel = new NotificationChannel(
-                    "pushup_reminders",
-                    "Pushup Reminders",
-                    NotificationImportance.High)
-                {
-                    Description = "Daily reminders to do your pushups",
-                    LockscreenVisibility = NotificationVisibility.Public
-                };
-                
-                channel.EnableVibration(true);
-                notificationManager.CreateNotificationChannel(channel);
-            }
-            
-            // Create notification intent
-            var notificationIntent = new Intent(context, Java.Lang.Class.ForName("onepushup.MainActivity"));
-            notificationIntent.SetFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop | ActivityFlags.NewTask);
-            notificationIntent.SetAction(Intent.ActionMain);
-            notificationIntent.AddCategory(Intent.CategoryLauncher);
-            
-            var pendingIntent = PendingIntent.GetActivity(
-                context, 
-                0, 
-                notificationIntent, 
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // Get icon
-            int iconId = global::Android.Resource.Drawable.IcDialogInfo;
-            
-            // Build test notification
-            var builder = new NotificationCompat.Builder(context, "pushup_reminders")
-                .SetContentTitle("OnePushUp Test")
-                .SetContentText($"Notification system is working! Current time: {DateTime.Now:HH:mm:ss}")
-                .SetSmallIcon(iconId)
-                .SetContentIntent(pendingIntent)
-                .SetAutoCancel(true)
-                .SetPriority(NotificationCompat.PriorityHigh)
-                .SetVisibility(NotificationCompat.VisibilityPublic);
-            
-            // Show the notification
-            int notificationId = intent.GetIntExtra("notification_id", 999);
-            notificationManager.Notify(notificationId, builder.Build());
-            
-            Logger.LogInformation("NotificationReceiver: Test notification displayed at {Time}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error showing test notification");
-        }
-    }
-    
-    private void WakeDeviceScreen(Context context)
-    {
-        try
-        {
-            // Acquire a wake lock to wake up the screen if it's off
-            var powerManager = context.GetSystemService(Context.PowerService) as PowerManager;
-            if (powerManager == null) return;
-            
-            var wakeLock = powerManager.NewWakeLock(WakeLockFlags.ScreenBright | WakeLockFlags.AcquireCausesWakeup, "OnePushUp::NotificationWakeLock");
-            wakeLock.Acquire(5000); // Hold for 5 seconds
-            
-            Logger.LogInformation("NotificationReceiver: Acquired wake lock to ensure notification visibility");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error waking device screen");
-        }
-    }
-    
-    private void RestoreNotificationsAfterReboot(Context context)
-    {
-        try
-        {
-            // Check if notifications were enabled before reboot
-            bool enabled = Preferences.Default.Get(EnabledKey, false);
-            if (!enabled)
-            {
-                Logger.LogInformation("NotificationReceiver: Notifications were disabled, not restoring");
-                return;
-            }
-            
-            // Get the stored notification time
-            long timeTicks = Preferences.Default.Get(TimeKey, 0L);
-            if (timeTicks == 0)
-            {
-                Logger.LogInformation("NotificationReceiver: No notification time stored, using default");
-                timeTicks = NotificationService.DefaultNotificationTime.Ticks; // Default to 8:00 AM
-            }
-
-            var time = TimeSpan.FromTicks(timeTicks);
-            Logger.LogInformation("NotificationReceiver: Restoring notification for {Time}", time.ToString("hh\\:mm"));
-            
-            // Calculate when to send the notification
-            var now = DateTime.Now;
-            
-            // Create a time that's specific to today at the desired hour/minute
-            var notificationTime = new DateTime(
-                now.Year, now.Month, now.Day, 
-                time.Hours, time.Minutes, 0);
-            
-            // If the time has already passed today, schedule for tomorrow
-            if (notificationTime <= now)
-            {
-                notificationTime = notificationTime.AddDays(1);
-                Logger.LogInformation("NotificationReceiver: Time already passed today, scheduling for tomorrow");
-            }
-            
-            // APPROACH 1: Use Calendar and RTC
-            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
-            calendar.Set(Java.Util.CalendarField.HourOfDay, time.Hours);
-            calendar.Set(Java.Util.CalendarField.Minute, time.Minutes);
-            calendar.Set(Java.Util.CalendarField.Second, 0);
-            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
-            
-            // If the time has already passed today, add one day
-            var nowMillis = Java.Lang.JavaSystem.CurrentTimeMillis();
-            if (calendar.TimeInMillis <= nowMillis) 
-            {
-                calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
-            }
-            
-            var triggerAtMillis = calendar.TimeInMillis;
-            Logger.LogInformation("NotificationReceiver: Will trigger at {CalendarTime}", calendar.Time);
-            
-            // Schedule using AlarmManager
-            var alarmManager = context.GetSystemService(Context.AlarmService) as AlarmManager;
-            if (alarmManager == null)
-            {
-                Logger.LogError("NotificationReceiver: Failed to get AlarmManager service");
-                return;
-            }
-            
-            // IMPORTANT: Set multiple alarms with different intents and request codes
-            // to ensure at least one of them works
-            
-            // 1. Exact alarm
-            var exactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            exactIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            exactIntent.PutExtra("notification_id", 1);
-            exactIntent.PutExtra("notification_time", $"{calendar.Time}");
-            exactIntent.PutExtra("approach", "exact");
-            
-            var exactPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                1,
-                exactIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // 2. Inexact alarm
-            var inexactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            inexactIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            inexactIntent.PutExtra("notification_id", 2);
-            inexactIntent.PutExtra("notification_time", $"{calendar.Time}");
-            inexactIntent.PutExtra("approach", "inexact");
-            
-            var inexactPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                2,
-                inexactIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // 3. Repeating alarm
-            var repeatingIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            repeatingIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            repeatingIntent.PutExtra("notification_id", 3);
-            repeatingIntent.PutExtra("notification_time", $"{calendar.Time}");
-            repeatingIntent.PutExtra("approach", "repeating");
-            
-            var repeatingPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                3,
-                repeatingIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // Set alarms based on API level
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
-            {
-                // For newer Android versions, use SetExactAndAllowWhileIdle
-                try 
-                {
-                    alarmManager.SetExactAndAllowWhileIdle(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        exactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Exact alarm set after boot");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting exact alarm");
-                }
-                
-                // Also set an inexact alarm as backup
-                try
-                {
-                    alarmManager.Set(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        inexactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Inexact alarm set after boot");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting inexact alarm");
-                }
-            }
-            else
-            {
-                // For older Android versions
-                try
-                {
-                    alarmManager.SetExact(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        exactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Exact alarm set for older Android");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting exact alarm on older Android");
-                }
-            }
-            
-            // Always set a repeating alarm as a reliable backup
-            try
-            {
-                alarmManager.SetRepeating(
-                    AlarmType.RtcWakeup,
-                    triggerAtMillis,
-                    AlarmManager.IntervalDay, // 24 hours in milliseconds
-                    repeatingPendingIntent);
-
-                Logger.LogInformation("NotificationReceiver: Repeating alarm set as backup");
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "NotificationReceiver: Error setting repeating alarm");
-            }
-            
-            // Set window alarms as additional backup (+/- 2 minutes)
-            SetWindowAlarm(context, alarmManager, time, -2, 101);
-            SetWindowAlarm(context, alarmManager, time, -1, 102);
-            SetWindowAlarm(context, alarmManager, time, 1, 103);
-            SetWindowAlarm(context, alarmManager, time, 2, 104);
-            
-            Logger.LogInformation("NotificationReceiver: Multiple alarms scheduled after boot/restore");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error restoring notifications");
-        }
-    }
-    
-    private void RescheduleForTomorrow(Context context)
-    {
-        try
-        {
-            // Make sure notifications are still enabled
-            bool enabled = Preferences.Default.Get(EnabledKey, false);
-            if (!enabled)
-            {
-                Logger.LogInformation("NotificationReceiver: Notifications are disabled, not rescheduling");
-                return;
-            }
-            
-            // Get the notification time preference
-            long timeTicks = Preferences.Default.Get(TimeKey, 0L);
-            if (timeTicks == 0)
-            {
-                Logger.LogInformation("NotificationReceiver: No notification time stored, using default");
-                timeTicks = NotificationService.DefaultNotificationTime.Ticks; // Default to 8:00 AM
-            }
-
-            TimeSpan scheduledTime = TimeSpan.FromTicks(timeTicks);
-            Logger.LogInformation("NotificationReceiver: Rescheduling for tomorrow at {Time}", scheduledTime.ToString("hh\\:mm"));
-            
-            // Calculate next notification time using Calendar
-            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
-            calendar.Set(Java.Util.CalendarField.HourOfDay, scheduledTime.Hours);
-            calendar.Set(Java.Util.CalendarField.Minute, scheduledTime.Minutes);
-            calendar.Set(Java.Util.CalendarField.Second, 0);
-            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
-            
-            // Add one day to ensure it's tomorrow
-            calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
-            
-            var triggerAtMillis = calendar.TimeInMillis;
-            
-            // Get AlarmManager
-            var alarmManager = context.GetSystemService(Context.AlarmService) as AlarmManager;
-            if (alarmManager == null)
-            {
-                Logger.LogError("NotificationReceiver: Failed to get AlarmManager service for rescheduling");
-                return;
-            }
-            
-            // Create multiple intents with different actions/request codes
-            
-            // 1. Exact alarm for tomorrow
-            var exactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            exactIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            exactIntent.PutExtra("notification_id", 1);
-            exactIntent.PutExtra("notification_time", $"{calendar.Time}");
-            exactIntent.PutExtra("approach", "exact_tomorrow");
-            
-            var exactPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                1,
-                exactIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // 2. Inexact alarm for tomorrow
-            var inexactIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            inexactIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            inexactIntent.PutExtra("notification_id", 2);
-            inexactIntent.PutExtra("notification_time", $"{calendar.Time}");
-            inexactIntent.PutExtra("approach", "inexact_tomorrow");
-            
-            var inexactPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                2,
-                inexactIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // 3. Repeating alarm
-            var repeatingIntent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            repeatingIntent.SetAction(ACTION_DAILY_NOTIFICATION);
-            repeatingIntent.PutExtra("notification_id", 3);
-            repeatingIntent.PutExtra("notification_time", $"{calendar.Time}");
-            repeatingIntent.PutExtra("approach", "repeating_tomorrow");
-            
-            var repeatingPendingIntent = PendingIntent.GetBroadcast(
-                context,
-                3,
-                repeatingIntent,
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // Set all alarm types based on API level
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
-            {
-                try
-                {
-                    alarmManager.SetExactAndAllowWhileIdle(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        exactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Exact alarm rescheduled for tomorrow at {CalendarTime}", calendar.Time);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting exact alarm for tomorrow");
-                }
-                
-                try
-                {
-                    alarmManager.Set(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        inexactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Inexact alarm set for tomorrow");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting inexact alarm for tomorrow");
-                }
-            }
-            else
-            {
-                try
-                {
-                    alarmManager.SetExact(
-                        AlarmType.RtcWakeup,
-                        triggerAtMillis,
-                        exactPendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Alarm rescheduled for tomorrow at {CalendarTime}", calendar.Time);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting exact alarm for older Android");
-                }
-            }
-            
-            // Set repeating alarm
-            try
-            {
-                alarmManager.SetRepeating(
-                    AlarmType.RtcWakeup,
-                    triggerAtMillis,
-                    AlarmManager.IntervalDay,
-                    repeatingPendingIntent);
-
-                Logger.LogInformation("NotificationReceiver: Repeating alarm set for tomorrow at {CalendarTime}", calendar.Time);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "NotificationReceiver: Error setting repeating alarm");
-            }
-            
-            // Also set window alarms for tomorrow
-            SetWindowAlarm(context, alarmManager, scheduledTime, -2, 101);
-            SetWindowAlarm(context, alarmManager, scheduledTime, -1, 102);
-            SetWindowAlarm(context, alarmManager, scheduledTime, 1, 103);
-            SetWindowAlarm(context, alarmManager, scheduledTime, 2, 104);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error rescheduling for tomorrow");
-        }
-    }
-    
-    private void SetWindowAlarm(Context context, AlarmManager alarmManager, TimeSpan targetTime, int minuteOffset, int requestCode)
-    {
-        try
-        {
-            // Create a calendar for the offset time
-            var calendar = Java.Util.Calendar.GetInstance(Java.Util.TimeZone.Default);
-            calendar.Set(Java.Util.CalendarField.HourOfDay, targetTime.Hours);
-            calendar.Set(Java.Util.CalendarField.Minute, targetTime.Minutes + minuteOffset);
-            calendar.Set(Java.Util.CalendarField.Second, 0);
-            calendar.Set(Java.Util.CalendarField.Millisecond, 0);
-            
-            // If the time has already passed today, add one day
-            if (calendar.TimeInMillis <= Java.Lang.JavaSystem.CurrentTimeMillis()) 
-            {
-                calendar.Add(Java.Util.CalendarField.DayOfYear, 1);
-            }
-            
-            var windowTriggerAtMillis = calendar.TimeInMillis;
-            
-            // Create intent with unique request code for this window alarm
-            var intent = new Intent(context, Java.Lang.Class.FromType(typeof(NotificationReceiver)));
-            intent.SetAction(ACTION_DAILY_NOTIFICATION);
-            intent.PutExtra("notification_id", requestCode);
-            intent.PutExtra("window_alarm", true);
-            intent.PutExtra("minute_offset", minuteOffset);
-            intent.PutExtra("approach", $"window_{minuteOffset}");
-            
-            var pendingIntent = PendingIntent.GetBroadcast(
-                context, 
-                requestCode, 
-                intent, 
-                PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
-            
-            // Set the alarm
-            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
-            {
-                try
-                {
-                    alarmManager.SetExactAndAllowWhileIdle(
-                        AlarmType.RtcWakeup,
-                        windowTriggerAtMillis,
-                        pendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Window alarm set for {Offset} minute(s) offset", (minuteOffset > 0 ? "+" : "") + minuteOffset);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting window alarm");
-                }
-            }
-            else
-            {
-                try
-                {
-                    alarmManager.SetExact(
-                        AlarmType.RtcWakeup,
-                        windowTriggerAtMillis,
-                        pendingIntent);
-
-                    Logger.LogInformation("NotificationReceiver: Window alarm set for {Offset} minute(s) offset", (minuteOffset > 0 ? "+" : "") + minuteOffset);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "NotificationReceiver: Error setting window alarm for older Android");
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "NotificationReceiver: Error setting window alarm with offset {Offset}", minuteOffset);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract intent actions and extras into `NotificationIntentConstants`
- Move alarm restoration and rescheduling logic into an injectable `AlarmScheduler`
- Shift notification display functionality into `NotificationDisplayer` and delegate from `NotificationReceiver`
- Register new Android services in DI container

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while accessing package repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaa8fe304832ebe6f0291c025268a