### PR TITLE
Use EF query to compute daily totals

### DIFF
--- a/OnePushup/Repositories/TrainingEntryRepository.cs
+++ b/OnePushup/Repositories/TrainingEntryRepository.cs
@@ -80,7 +80,12 @@ public class TrainingEntryRepository : ITrainingEntryRepository
         return await _db.TrainingEntries
             .AsNoTracking()
             .Where(e => e.UserId == userId && e.NumberOfRepetitions > 0)
-            .GroupBy(e => e.DateTime.AddMinutes(offsetMinutes).Date)
+            .Select(e => new
+            {
+                LocalDate = e.DateTime.AddMinutes(offsetMinutes).Date,
+                e.NumberOfRepetitions
+            })
+            .GroupBy(e => e.LocalDate)
             .Select(g => new DailyTotal(g.Key, g.Sum(e => e.NumberOfRepetitions)))
             .ToListAsync();
     }


### PR DESCRIPTION
## Summary
- Group and sum user entries by day directly in SQL via projection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aebaa657d8832eb422b6551ba41526