### PR TITLE
Refine data layer and fix streak calculation

### DIFF
--- a/OnePushup/Services/TrainingService.cs
+++ b/OnePushup/Services/TrainingService.cs
@@ -17,7 +17,7 @@ public class TrainingService
     {
         var entry = new TrainingEntry
         {
-            DateTime = DateTimeOffset.UtcNow,
+            DateTime = DateTimeOffset.Now,
             NumberOfRepetitions = repetitions,
             UserId = userId
         };


### PR DESCRIPTION
## Summary
- optimize training entry queries for today's entries and streak calculations
- compute daily totals using per-entry local time for accurate streaks
- create entries with local timestamp for consistent time zone handling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af31da4428832e8052e1ec195636ef