### PR TITLE
Add swipe navigation between pages

### DIFF
--- a/OnePushup/MainPage.xaml
+++ b/OnePushup/MainPage.xaml
@@ -5,6 +5,10 @@
              x:Class="OnePushUp.MainPage">
 
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
+        <BlazorWebView.GestureRecognizers>
+            <SwipeGestureRecognizer Direction="Left" Swiped="OnSwipedLeft" />
+            <SwipeGestureRecognizer Direction="Right" Swiped="OnSwipedRight" />
+        </BlazorWebView.GestureRecognizers>
         <BlazorWebView.RootComponents>
             <RootComponent Selector="#app" ComponentType="{x:Type local:Components.Routes}" />
         </BlazorWebView.RootComponents>

--- a/OnePushup/MainPage.xaml.cs
+++ b/OnePushup/MainPage.xaml.cs
@@ -1,9 +1,44 @@
-﻿namespace OnePushUp;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OnePushUp;
 
 public partial class MainPage : ContentPage
 {
+    private NavigationManager? Navigation =>
+        blazorWebView?.Handler?.MauiContext?.Services.GetService<NavigationManager>();
+
     public MainPage()
     {
         InitializeComponent();
     }
+
+    private void OnSwipedLeft(object sender, SwipedEventArgs e)
+    {
+        var nav = Navigation;
+        if (nav == null) return;
+        var uri = new Uri(nav.Uri);
+        var next = uri.AbsolutePath switch
+        {
+            "/" => "/stats",
+            "/stats" => "/settings",
+            _ => "/"
+        };
+        nav.NavigateTo(next);
+    }
+
+    private void OnSwipedRight(object sender, SwipedEventArgs e)
+    {
+        var nav = Navigation;
+        if (nav == null) return;
+        var uri = new Uri(nav.Uri);
+        var next = uri.AbsolutePath switch
+        {
+            "/" => "/settings",
+            "/stats" => "/",
+            _ => "/stats"
+        };
+        nav.NavigateTo(next);
+    }
 }
+


### PR DESCRIPTION
## Summary
- Add swipe gesture recognizers to the BlazorWebView so left/right swipes navigate across Daily Goal, Stats, and Settings
- Handle swipe events in MainPage code-behind to route to the next or previous page

## Testing
- `dotnet build OnePushUp.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af39cc1da4832ea2ebe42609a42e59