### PR TITLE
Align Settings page spacing with Home/Stats

### DIFF
--- a/OnePushup/Components/Pages/Settings.razor
+++ b/OnePushup/Components/Pages/Settings.razor
@@ -4,7 +4,7 @@
 @inject UserService UserService
 @inject NotificationService NotificationService
 
-<div class="container my-1">
+<div class="container mt-4">
     <div class="row">
         <div class="col-md-6">
             @if (CurrentUser != null)


### PR DESCRIPTION
## Summary
- Use `container mt-4` on Settings page outer wrapper to match other pages

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b050d1e154832ea57749535f0c6d61