### PR TITLE
Ensure UsersRepository updates gender

### DIFF
--- a/OneActivity.Core/Repositories/UsersRepository.cs
+++ b/OneActivity.Core/Repositories/UsersRepository.cs
@@ -33,6 +33,7 @@ public class UsersRepository : IUsersRepository
         }
 
         existingUser.NickName = user.NickName;
+        existingUser.Gender = user.Gender;
         await _db.SaveChangesAsync();
         return true;
     }

--- a/tests/OneActivity.Tests/UsersRepositoryTests.cs
+++ b/tests/OneActivity.Tests/UsersRepositoryTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using OneActivity.Core.Repositories;
+using OneActivity.Data;
+using Xunit;
+
+namespace OneActivity.Tests;
+
+public class UsersRepositoryTests
+{
+    private static OneActivityDbContext CreateDbContext()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<OneActivityDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        var db = new OneActivityDbContext(options);
+        db.Database.EnsureCreated();
+        return db;
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsGenderChange()
+    {
+        using var db = CreateDbContext();
+        var repo = new UsersRepository(db);
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            NickName = "Initial",
+            Gender = 0
+        };
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        var updatedUser = new User
+        {
+            Id = user.Id,
+            NickName = "Updated",
+            Gender = 1
+        };
+
+        var result = await repo.UpdateAsync(updatedUser);
+
+        Assert.True(result);
+        var storedUser = await db.Users.FindAsync(user.Id);
+        Assert.NotNull(storedUser);
+        Assert.Equal(1, storedUser!.Gender);
+    }
+}


### PR DESCRIPTION
## Summary
- Copy `Gender` from input user to existing user in `UsersRepository.UpdateAsync`
- Add `UsersRepositoryTests` to verify that gender updates persist

## Testing
- `dotnet test` *(fails: command not found)*
- Attempted `apt-get update` *(403 Forbidden)*
- Attempted `apt-get install -y dotnet-sdk-8.0` *(Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a9ae523c832eb38e5ecec46d6286