### PR TITLE
Fix streak reset logic when recent entries missing and add tests

### DIFF
--- a/OneActivity.Core/Repositories/ActivityEntryRepository.cs
+++ b/OneActivity.Core/Repositories/ActivityEntryRepository.cs
@@ -60,6 +60,9 @@ public class ActivityEntryRepository : IActivityEntryRepository
         if (today != null && today.Quantity == 0) return (new List<DateTime>(), new List<DailyTotal>());
         var entries = await GetEntriesByLocalDateAsync(userId);
         if (!entries.Any()) return (new List<DateTime>(), entries);
+        var (start, _) = GetUserLocalDateRange();
+        var gap = (start.Date - entries[0].Date).Days;
+        if (today == null && gap > 1) return (new List<DateTime>(), entries);
         var dates = entries.Select(e => e.Date).ToList();
         var streak = 1;
         for (int i = 0; i < dates.Count - 1; i++)

--- a/tests/OneActivity.Tests/ActivityEntryRepositoryTests.cs
+++ b/tests/OneActivity.Tests/ActivityEntryRepositoryTests.cs
@@ -42,4 +42,88 @@ public class ActivityEntryRepositoryTests
         var hasToday = await repo.HasEntryForTodayAsync(userId);
         Assert.True(hasToday);
     }
+
+    [Fact]
+    public async Task GetCurrentStreakAsync_ReturnsZero_WhenNoRecentEntries()
+    {
+        using var db = CreateDbContext();
+        var repo = new ActivityEntryRepository(db);
+        var userId = Guid.NewGuid();
+
+        db.Users.Add(new User { Id = userId, NickName = "Test" });
+        db.ActivityEntries.Add(new ActivityEntry
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Quantity = 10,
+            DateTime = DateTimeOffset.UtcNow.AddDays(-2)
+        });
+        await db.SaveChangesAsync();
+
+        var streak = await repo.GetCurrentStreakAsync(userId);
+
+        Assert.Equal(0, streak);
+    }
+
+    [Fact]
+    public async Task GetCurrentStreakAsync_Persists_WhenTrainingYesterday()
+    {
+        using var db = CreateDbContext();
+        var repo = new ActivityEntryRepository(db);
+        var userId = Guid.NewGuid();
+
+        db.Users.Add(new User { Id = userId, NickName = "Test" });
+        db.ActivityEntries.AddRange(
+            new ActivityEntry
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Quantity = 10,
+                DateTime = DateTimeOffset.UtcNow.AddDays(-2)
+            },
+            new ActivityEntry
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Quantity = 20,
+                DateTime = DateTimeOffset.UtcNow.AddDays(-1)
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var streak = await repo.GetCurrentStreakAsync(userId);
+
+        Assert.Equal(2, streak);
+    }
+
+    [Fact]
+    public async Task GetCurrentStreakAsync_IncludesToday()
+    {
+        using var db = CreateDbContext();
+        var repo = new ActivityEntryRepository(db);
+        var userId = Guid.NewGuid();
+
+        db.Users.Add(new User { Id = userId, NickName = "Test" });
+        db.ActivityEntries.AddRange(
+            new ActivityEntry
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Quantity = 15,
+                DateTime = DateTimeOffset.UtcNow.AddDays(-1)
+            },
+            new ActivityEntry
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Quantity = 25,
+                DateTime = DateTimeOffset.UtcNow
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var streak = await repo.GetCurrentStreakAsync(userId);
+
+        Assert.Equal(2, streak);
+    }
 }


### PR DESCRIPTION
## Summary
- Reset current streak when last entry is older than yesterday
- Cover streak behavior for missing days, yesterday-only training, and today's training

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b747c268cc832e8532916d94b3c281