### PR TITLE
Localize user creation and nickname settings

### DIFF
--- a/OneActivity.Core/Components/HomeComponents/CreateUser.razor
+++ b/OneActivity.Core/Components/HomeComponents/CreateUser.razor
@@ -1,11 +1,10 @@
 @page "/create-user"
 
-
-<h3>How would you like me to call you?</h3>
+<h3>@Shared.CreateUserPrompt</h3>
 
 <EditForm Model="this" OnValidSubmit="HandleSubmit">
-    <InputText @bind-Value="NickName" placeholder="Enter your nickname (you can change it later)" />
-    <button type="submit">Submit</button>
+    <InputText @bind-Value="NickName" placeholder="@Shared.CreateUserNicknamePlaceholder" />
+    <button type="submit">@Content.SaveText</button>
     
     @if (!string.IsNullOrEmpty(ErrorMessage))
     {

--- a/OneActivity.Core/Components/HomeComponents/CreateUser.razor.cs
+++ b/OneActivity.Core/Components/HomeComponents/CreateUser.razor.cs
@@ -7,6 +7,10 @@ public partial class CreateUser : ComponentBase
 {
     [Inject]
     private UserService UserService { get; set; } = default!;
+    [Inject]
+    private ISharedContent Shared { get; set; } = default!;
+    [Inject]
+    private IActivityContent Content { get; set; } = default!;
     
     public string NickName { get; set; } = string.Empty;
     public string ErrorMessage { get; set; } = string.Empty;
@@ -21,13 +25,13 @@ public partial class CreateUser : ComponentBase
         
         if (string.IsNullOrWhiteSpace(trimmedNickName))
         {
-            ErrorMessage = "Nickname cannot be empty.";
+            ErrorMessage = Shared.NicknameEmptyError;
             return;
         }
-        
+
         if (trimmedNickName.Length > 15)
         {
-            ErrorMessage = "Nickname must be at most 15 characters.";
+            ErrorMessage = Shared.NicknameTooLongError;
             return;
         }
         
@@ -42,12 +46,12 @@ public partial class CreateUser : ComponentBase
             }
             else
             {
-                ErrorMessage = "Failed to create user. Please try again.";
+                ErrorMessage = Shared.CreateUserFailed;
             }
         }
         catch (Exception ex)
         {
-            ErrorMessage = $"Error creating user: {ex.Message}";
+            ErrorMessage = $"{Shared.CreateUserErrorPrefix} {ex.Message}";
         }
     }
 }

--- a/OneActivity.Core/Components/SettingsComponents/EditNickname.razor
+++ b/OneActivity.Core/Components/SettingsComponents/EditNickname.razor
@@ -1,30 +1,32 @@
 @using OneActivity.Core.Services
 @inject UserService UserService
+@inject ISharedContent Shared
+@inject IActivityContent Content
 
 <div class="card mt-4">
     <div class="card-header">
-        <h3>Edit Nickname</h3>
+        <h3>@Shared.EditNicknameTitle</h3>
     </div>
     <div class="card-body">
         @if (_isLoading)
         {
-            <p>Loading...</p>
+            <p>@Content.LoadingText</p>
         }
         else
         {
             <EditForm Model="@this" OnValidSubmit="SaveNickname">
                 <div class="mb-3">
-                    <label for="nickname" class="form-label">Nickname</label>
+                    <label for="nickname" class="form-label">@Shared.NicknameLabel</label>
                     <InputText id="nickname" class="form-control" @bind-Value="_nickname" />
                 </div>
                 <button type="submit" class="btn btn-primary" disabled="@_isSaving">
                     @if (_isSaving)
                     {
-                        <span>Saving...</span>
+                        <span>@Content.SavingText</span>
                     }
                     else
                     {
-                        <span>Save</span>
+                        <span>@Content.SaveText</span>
                     }
                 </button>
             </EditForm>

--- a/OneActivity.Core/Components/SettingsComponents/EditNickname.razor.cs
+++ b/OneActivity.Core/Components/SettingsComponents/EditNickname.razor.cs
@@ -38,7 +38,7 @@ public partial class EditNickname
             }
             else
             {
-                _message = "No user found. Please create a user first.";
+                _message = Shared.NoUserProfileMessage;
                 _isError = true;
                 Logger.LogWarning("No user found in the database");
             }
@@ -46,7 +46,7 @@ public partial class EditNickname
         catch (Exception ex)
         {
             _isError = true;
-            _message = $"Error loading user data: {ex.Message}";
+            _message = $"{Shared.ErrorLoadingUserDataPrefix} {ex.Message}";
             Logger.LogError(ex, "Error loading user data");
         }
         finally
@@ -67,7 +67,7 @@ public partial class EditNickname
             if (_currentUser == null)
             {
                 _isError = true;
-                _message = "No user found to update.";
+                _message = Shared.NoUserProfileMessage;
                 Logger.LogWarning("Attempted to save nickname but no user was found");
                 return;
             }
@@ -75,7 +75,7 @@ public partial class EditNickname
             if (string.IsNullOrWhiteSpace(_nickname))
             {
                 _isError = true;
-                _message = "Nickname cannot be empty.";
+                _message = Shared.NicknameEmptyError;
                 Logger.LogWarning("Attempted to save empty nickname");
                 return;
             }
@@ -92,19 +92,19 @@ public partial class EditNickname
             var success = await UserService.UpdateUserAsync(userDto);
             if (success)
             {
-                _message = "Nickname updated successfully!";
+                _message = Shared.NicknameUpdateSuccess;
                 _isError = false;
             }
             else
             {
-                _message = "Failed to update nickname. Please try again.";
+                _message = Shared.NicknameUpdateFailed;
                 _isError = true;
             }
         }
         catch (Exception ex)
         {
             _isError = true;
-            _message = $"Error updating nickname: {ex.Message}";
+            _message = $"{Shared.ErrorUpdatingNicknamePrefix} {ex.Message}";
             Logger.LogError(ex, "Error updating nickname");
         }
         finally

--- a/OneActivity.Core/Components/SettingsComponents/LanguageSettings.razor
+++ b/OneActivity.Core/Components/SettingsComponents/LanguageSettings.razor
@@ -10,8 +10,8 @@
         <div class="mb-2">
             <label for="lang-select" class="form-label">@Shared.LanguageChooseLabel</label>
             <select id="lang-select" class="form-select" @bind="Selected">
-                <option value="en">English (EN)</option>
-                <option value="pl">Polski (PL)</option>
+                <option value="en">@Shared.LanguageEnglishOption</option>
+                <option value="pl">@Shared.LanguagePolishOption</option>
             </select>
         </div>
         <div class="small text-muted">

--- a/OneActivity.Core/Services/ISharedContent.cs
+++ b/OneActivity.Core/Services/ISharedContent.cs
@@ -2,6 +2,22 @@ namespace OneActivity.Core.Services;
 
 public interface ISharedContent
 {
+    // Create user
+    string CreateUserPrompt { get; }
+    string CreateUserNicknamePlaceholder { get; }
+    string NicknameEmptyError { get; }
+    string NicknameTooLongError { get; }
+    string CreateUserFailed { get; }
+    string CreateUserErrorPrefix { get; }
+
+    // Edit nickname
+    string EditNicknameTitle { get; }
+    string NicknameLabel { get; }
+    string NicknameUpdateSuccess { get; }
+    string NicknameUpdateFailed { get; }
+    string ErrorLoadingUserDataPrefix { get; }
+    string ErrorUpdatingNicknamePrefix { get; }
+
     // Settings general
     string NoUserProfileMessage { get; }
 
@@ -9,6 +25,8 @@ public interface ISharedContent
     string LanguageCardTitle { get; }
     string LanguageChooseLabel { get; }
     string CurrentPrefix { get; }
+    string LanguageEnglishOption { get; }
+    string LanguagePolishOption { get; }
 
     // Gender card
     string GenderCardTitle { get; }

--- a/OneActivity.Core/Services/SharedContentEn.cs
+++ b/OneActivity.Core/Services/SharedContentEn.cs
@@ -2,11 +2,27 @@ namespace OneActivity.Core.Services;
 
 public class SharedContentEn : ISharedContent
 {
+    public string CreateUserPrompt => "How would you like me to call you?";
+    public string CreateUserNicknamePlaceholder => "Enter your nickname (you can change it later)";
+    public string NicknameEmptyError => "Nickname cannot be empty.";
+    public string NicknameTooLongError => "Nickname must be at most 15 characters.";
+    public string CreateUserFailed => "Failed to create user. Please try again.";
+    public string CreateUserErrorPrefix => "Error creating user:";
+
+    public string EditNicknameTitle => "Edit Nickname";
+    public string NicknameLabel => "Nickname";
+    public string NicknameUpdateSuccess => "Nickname updated successfully!";
+    public string NicknameUpdateFailed => "Failed to update nickname. Please try again.";
+    public string ErrorLoadingUserDataPrefix => "Error loading user data:";
+    public string ErrorUpdatingNicknamePrefix => "Error updating nickname:";
+
     public string NoUserProfileMessage => "No user profile found. Please create a user profile from the home page first.";
 
     public string LanguageCardTitle => "Language";
     public string LanguageChooseLabel => "Choose your language";
     public string CurrentPrefix => "Current:";
+    public string LanguageEnglishOption => "English (EN)";
+    public string LanguagePolishOption => "Polish (PL)";
 
     public string GenderCardTitle => "Gender";
     public string GenderChooseLabel => "Choose your form";

--- a/OneActivity.Core/Services/SharedContentLocalized.cs
+++ b/OneActivity.Core/Services/SharedContentLocalized.cs
@@ -9,15 +9,34 @@ public class SharedContentLocalized : ISharedContent
     { _lang = lang; _en = en; _pl = pl; }
     private ISharedContent Cur => _lang.CurrentCulture.TwoLetterISOLanguageName.ToLowerInvariant() == "pl" ? _pl : _en;
 
+    public string CreateUserPrompt => Cur.CreateUserPrompt;
+    public string CreateUserNicknamePlaceholder => Cur.CreateUserNicknamePlaceholder;
+    public string NicknameEmptyError => Cur.NicknameEmptyError;
+    public string NicknameTooLongError => Cur.NicknameTooLongError;
+    public string CreateUserFailed => Cur.CreateUserFailed;
+    public string CreateUserErrorPrefix => Cur.CreateUserErrorPrefix;
+
+    public string EditNicknameTitle => Cur.EditNicknameTitle;
+    public string NicknameLabel => Cur.NicknameLabel;
+    public string NicknameUpdateSuccess => Cur.NicknameUpdateSuccess;
+    public string NicknameUpdateFailed => Cur.NicknameUpdateFailed;
+    public string ErrorLoadingUserDataPrefix => Cur.ErrorLoadingUserDataPrefix;
+    public string ErrorUpdatingNicknamePrefix => Cur.ErrorUpdatingNicknamePrefix;
+
     public string NoUserProfileMessage => Cur.NoUserProfileMessage;
+
     public string LanguageCardTitle => Cur.LanguageCardTitle;
     public string LanguageChooseLabel => Cur.LanguageChooseLabel;
     public string CurrentPrefix => Cur.CurrentPrefix;
+    public string LanguageEnglishOption => Cur.LanguageEnglishOption;
+    public string LanguagePolishOption => Cur.LanguagePolishOption;
+
     public string GenderCardTitle => Cur.GenderCardTitle;
     public string GenderChooseLabel => Cur.GenderChooseLabel;
     public string GenderUnspecified => Cur.GenderUnspecified;
     public string GenderMale => Cur.GenderMale;
     public string GenderFemale => Cur.GenderFemale;
+
     public string NotificationTestingTitle => Cur.NotificationTestingTitle;
     public string NotificationTestingDescription => Cur.NotificationTestingDescription;
     public string NotificationTestingButtonIdle => Cur.NotificationTestingButtonIdle;

--- a/OneActivity.Core/Services/SharedContentPl.cs
+++ b/OneActivity.Core/Services/SharedContentPl.cs
@@ -2,11 +2,27 @@ namespace OneActivity.Core.Services;
 
 public class SharedContentPl : ISharedContent
 {
+    public string CreateUserPrompt => "Jak mam się do Ciebie zwracać?";
+    public string CreateUserNicknamePlaceholder => "Wpisz swój pseudonim (możesz go później zmienić)";
+    public string NicknameEmptyError => "Pseudonim nie może być pusty.";
+    public string NicknameTooLongError => "Pseudonim może mieć maksymalnie 15 znaków.";
+    public string CreateUserFailed => "Nie udało się utworzyć użytkownika. Spróbuj ponownie.";
+    public string CreateUserErrorPrefix => "Błąd tworzenia użytkownika:";
+
+    public string EditNicknameTitle => "Edytuj pseudonim";
+    public string NicknameLabel => "Pseudonim";
+    public string NicknameUpdateSuccess => "Pseudonim zaktualizowany pomyślnie!";
+    public string NicknameUpdateFailed => "Nie udało się zaktualizować pseudonimu. Spróbuj ponownie.";
+    public string ErrorLoadingUserDataPrefix => "Błąd wczytywania danych użytkownika:";
+    public string ErrorUpdatingNicknamePrefix => "Błąd aktualizacji pseudonimu:";
+
     public string NoUserProfileMessage => "Nie znaleziono profilu użytkownika. Utwórz profil na stronie głównej.";
 
     public string LanguageCardTitle => "Język";
     public string LanguageChooseLabel => "Wybierz język";
     public string CurrentPrefix => "Aktualny:";
+    public string LanguageEnglishOption => "Angielski (EN)";
+    public string LanguagePolishOption => "Polski (PL)";
 
     public string GenderCardTitle => "Forma gramatyczna";
     public string GenderChooseLabel => "Wybierz swoją formę";


### PR DESCRIPTION
## Summary
- extract CreateUser strings to shared content and reuse content service in markup
- move EditNickname strings to shared content and use content service for labels
- localize language selection options via shared content properties

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b759b99b90832eacafb3b2c4b0fa77